### PR TITLE
add ability to version all projects as one

### DIFF
--- a/src/AutoVer/AutoVer.csproj
+++ b/src/AutoVer/AutoVer.csproj
@@ -25,7 +25,7 @@
       <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-      <PackageReference Include="System.Text.Json" Version="8.0.3" />
+      <PackageReference Include="System.Text.Json" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AutoVer/Commands/CommandFactory.cs
+++ b/src/AutoVer/Commands/CommandFactory.cs
@@ -18,7 +18,8 @@ public class CommandFactory(
     IConfigurationManager configurationManager,
     IChangelogHandler changelogHandler,
     IChangeFileHandler changeFileHandler,
-    IVersionHandler versionHandler
+    IVersionHandler versionHandler,
+    IVersionIncrementer versionIncrementer
     ) : ICommandFactory
 {
     private static readonly Option<string> OptionProjectPath = new("--project-path", Directory.GetCurrentDirectory, "Path to the project");
@@ -77,7 +78,13 @@ public class CommandFactory(
                 var optionNoTag = context.ParseResult.GetValueForOption(noTagOption);
                 var optionUseVersion = context.ParseResult.GetValueForOption(useVersionOption);
                 
-                var command = new VersionCommand(projectHandler, gitHandler, configurationManager, changeFileHandler, versionHandler);
+                var command = new VersionCommand(
+                    projectHandler, 
+                    gitHandler, 
+                    configurationManager, 
+                    changeFileHandler, 
+                    versionHandler,
+                    versionIncrementer);
                 await command.ExecuteAsync(optionProjectPath, optionIncrementType, optionSkipVersionTagCheck, optionNoCommit, optionNoTag, optionUseVersion);
                     
                 context.ExitCode = CommandReturnCodes.Success;

--- a/src/AutoVer/Models/ThreePartVersion.cs
+++ b/src/AutoVer/Models/ThreePartVersion.cs
@@ -1,6 +1,6 @@
 namespace AutoVer.Models;
 
-public class ThreePartVersion
+public class ThreePartVersion : IComparable<ThreePartVersion>
 {
     public required int Major { get; set; }
     public required int Minor { get; set; }
@@ -58,5 +58,45 @@ public class ThreePartVersion
             };
             return false;
         }
+    }
+    
+    public int CompareTo(ThreePartVersion? other)
+    {
+        if (other == null) return 1;
+
+        int result = Major.CompareTo(other.Major);
+        if (result != 0) return result;
+
+        result = Minor.CompareTo(other.Minor);
+        if (result != 0) return result;
+
+        result = Patch.CompareTo(other.Patch);
+        if (result != 0) return result;
+
+        return string.Compare(PrereleaseLabel, other.PrereleaseLabel, StringComparison.Ordinal);
+    }
+    
+    public static bool operator >(ThreePartVersion? left, ThreePartVersion? right)
+    {
+        if (left is null) return false;
+        return left.CompareTo(right) > 0;
+    }
+
+    public static bool operator <(ThreePartVersion? left, ThreePartVersion? right)
+    {
+        if (left is null) return right is not null;
+        return left.CompareTo(right) < 0;
+    }
+
+    public static bool operator >=(ThreePartVersion? left, ThreePartVersion? right)
+    {
+        if (left is null) return right is null;
+        return left.CompareTo(right) >= 0;
+    }
+
+    public static bool operator <=(ThreePartVersion? left, ThreePartVersion? right)
+    {
+        if (left is null) return true;
+        return left.CompareTo(right) <= 0;
     }
 }

--- a/src/AutoVer/Models/UserConfiguration.cs
+++ b/src/AutoVer/Models/UserConfiguration.cs
@@ -8,6 +8,7 @@ public class UserConfiguration
     internal bool PersistConfiguration { get; set; }
     public List<Project> Projects { get; set; } = [];
     public bool UseCommitsForChangelog { get; set; } = true;
+    public bool UseSameVersionForAllProjects { get; set; } = false;
         
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public IncrementType DefaultIncrementType { get; set; } = IncrementType.Patch;

--- a/src/AutoVer/Services/ChangelogHandler.cs
+++ b/src/AutoVer/Services/ChangelogHandler.cs
@@ -84,6 +84,19 @@ public class ChangelogHandler(
                 changeFile.Projects.RemoveAll(x => !configuredProjects.Contains(x.Name));
             }
 
+            if (configuration.UseSameVersionForAllProjects)
+            {
+                changeFiles.Add(new ChangeFile
+                {
+                     Projects = configuration.Projects.Select(x => new ProjectChange
+                     {
+                         Name = x.Name,
+                         Type = x.IncrementType,
+                         ChangelogMessages = new List<string>()
+                     }).ToList()
+                });
+            }
+
             var changelogCategories = new Dictionary<string, ChangelogCategory>();
             foreach (var changeFile in changeFiles)
             {
@@ -98,9 +111,6 @@ public class ChangelogHandler(
                     }
                     else
                     {
-                        if (project.ChangelogMessages.Count == 0)
-                            continue;
-                        
                         var configuredProject = configuration.Projects.First(x => x.Name.Equals(project.Name));
                         if (configuredProject.ProjectDefinition is null)
                             throw new InvalidProjectException($"The project '{configuredProject.Path}' is invalid.");
@@ -110,6 +120,13 @@ public class ChangelogHandler(
                             Name = configuredProject.Name,
                             Version = configuredProject.ProjectDefinition?.Version
                         };
+
+                        if (!configuration.UseSameVersionForAllProjects)
+                        {
+                            if (project.ChangelogMessages.Count == 0)
+                                continue;
+                        }
+                        
                         foreach (var changelogMessage in project.ChangelogMessages)
                         {
                             changelogCategory.Changes.Add(new ChangelogChange { Description = changelogMessage });

--- a/src/AutoVer/Services/IVersionIncrementer.cs
+++ b/src/AutoVer/Services/IVersionIncrementer.cs
@@ -6,4 +6,5 @@ public interface IVersionIncrementer
 {
     ThreePartVersion GetCurrentVersion(string? versionText);
     ThreePartVersion GetNextVersion(string? versionText, IncrementType incrementType, string? prereleaseLabel = null);
+    ThreePartVersion GetNextMaxVersion(List<UserConfiguration.Project> projects, IDictionary<string, IncrementType>? projectIncrements, IncrementType globalIncrementType);
 }


### PR DESCRIPTION
Using the new setting `UseSameVersionForAllProjects`, users will now be able to force all the configured projects to use the same version. This version will be determined by the project with the currently highest version.
As an example, if you have 3 projects in your AutoVer config file with the following versions:

* Project 1 (1.20.0)
* Project 2 (1.25.0)
* Project 3 (1.30.0)

The version 1.30.0 will be used for future versioning. Depending on what increment type you are using, all projects will have the following version:
* Patch: 1.30.1
* Minor: 1.31.0
* Major: 2.0.0