### PR TITLE
fix: fix error when using --use-version

### DIFF
--- a/.autover/changes/27ad7e46-2b02-4a45-aa84-7680e019ca91.json
+++ b/.autover/changes/27ad7e46-2b02-4a45-aa84-7680e019ca91.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "AutoVer",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed an issue when --use-version has the same version as the csproj and no version update is made. Previously, this would error out with a non-zero exit code."
+      ]
+    }
+  ]
+}

--- a/src/AutoVer/Commands/VersionCommand.cs
+++ b/src/AutoVer/Commands/VersionCommand.cs
@@ -140,7 +140,8 @@ public class VersionCommand(
 
         if (!optionNoCommit)
         {
-            gitHandler.CommitChanges(userConfiguration, versionHandler.GetNewReleaseName(userConfiguration));
+            if (gitHandler.HasStagedChanges(userConfiguration))
+                gitHandler.CommitChanges(userConfiguration, versionHandler.GetNewReleaseName(userConfiguration));
 
             if (!optionNoTag)
             {

--- a/src/AutoVer/Services/GitHandler.cs
+++ b/src/AutoVer/Services/GitHandler.cs
@@ -61,6 +61,17 @@ public class GitHandler(
         }
     }
 
+    public bool HasStagedChanges(UserConfiguration userConfiguration)
+    {
+        using (var gitRepository = new Repository(userConfiguration.GitRoot))
+        {
+            var headTree = gitRepository.Head.Tip.Tree;
+            var changes = gitRepository.Diff.Compare<TreeChanges>(headTree, DiffTargets.Index);
+
+            return changes.Count > 0;
+        }
+    }
+
     public void CommitChanges(UserConfiguration userConfiguration, string commitMessage)
     {
         using var gitRepository = new Repository(userConfiguration.GitRoot);

--- a/src/AutoVer/Services/IGitHandler.cs
+++ b/src/AutoVer/Services/IGitHandler.cs
@@ -14,4 +14,5 @@ public interface IGitHandler
     List<ConventionalCommit> GetVersionCommits(UserConfiguration userConfiguration, string? lastVersionTag = null);
     string GetFileByTag(string gitRoot, string tagName, string filePath);
     List<GitFile> GetFolderByTag(string gitRoot, string tagName, string folderPath);
+    bool HasStagedChanges(UserConfiguration userConfiguration);
 }

--- a/test/AutoVer.UnitTests/AutoVer.UnitTests.csproj
+++ b/test/AutoVer.UnitTests/AutoVer.UnitTests.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
-      <PackageReference Include="TUnit" Version="0.1.1099" />
+      <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
+      <PackageReference Include="TUnit" Version="0.19.32" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/AutoVer.UnitTests/VersionTest.cs
+++ b/test/AutoVer.UnitTests/VersionTest.cs
@@ -71,6 +71,57 @@ $@"{{
         await Assert.That(changelog).Contains("Important change");
         await Assert.That(GitUtilities.GetLastCommitMessage(tempDir)).IsEqualTo("Updated changelog");
     }
+    
+    [Test]
+    public async Task CsProj_UseChangeFiles_VersionNoChangedFiles()
+    {
+        string tempDir = TestContext.Current?.ObjectBag["tempDir"]?.ToString() ?? throw new Exception("Temp directory is null");
+
+        await Assert.That(await IOUtilities.CreateProject(tempDir, "src", "Project1")).IsTrue();
+        await IOUtilities.SetProjectVersion(Path.Combine(tempDir, "src", "Project1", "Project1.csproj"), "1.0.0");
+
+        string autoVerFile =
+$@"{{
+    ""Projects"": [
+        {{
+            ""Name"": ""Project1"",
+            ""Path"": ""src/Project1/Project1.csproj""
+        }}
+    ],
+    ""UseCommitsForChangelog"": false,
+    ""UseSameVersionForAllProjects"": false,
+    ""DefaultIncrementType"": ""Patch"",
+    ""ChangeFilesDetermineIncrementType"": true
+}}";
+
+        var autoVerFilePath = IOUtilities.AddAutoVerFile(tempDir, autoVerFile);
+        GitUtilities.StageChanges(tempDir, "*");
+        GitUtilities.CommitChanges(tempDir, "Initial Commit");
+
+        var changeFilePath = await IOUtilities.AddChangeFile("Project1", IncrementType.Patch, "Important change", tempDir);
+        GitUtilities.StageChanges(tempDir, changeFilePath);
+        GitUtilities.CommitChanges(tempDir, "First change");
+
+        var app = AutoVerUtilities.InitializeApp();
+        await Assert.That(app).IsNotNull();
+
+        var versionArgs = new[] { "version", "--project-path", tempDir, "--use-version", "1.0.0" };
+        var exitCode = await app!.Run(versionArgs);
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        await Assert.That(await IOUtilities.GetProjectVersion(Path.Combine(tempDir, "src", "Project1", "Project1.csproj"))).IsEqualTo("1.0.0");
+        await Assert.That(GitUtilities.GetLastTag(tempDir)).IsEqualTo($"release_{DateTime.UtcNow:yyyy-MM-dd}");
+
+        app = AutoVerUtilities.InitializeApp();
+        var changelogArgs = new[] { "changelog", "--project-path", tempDir };
+        exitCode = await app!.Run(changelogArgs);
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        var changelog = await IOUtilities.GetChangelog(tempDir);
+        await Assert.That(changelog).Contains($"Release {DateTime.UtcNow:yyyy-MM-dd}");
+        await Assert.That(changelog).Contains("Important change");
+        await Assert.That(GitUtilities.GetLastCommitMessage(tempDir)).IsEqualTo("Updated changelog");
+    }
 
     [Test]
     public async Task CsProj_DontUseChangeFiles_DefaultIncrement()


### PR DESCRIPTION
**Description**
If you run the `version` command with `--use-version` and that version is the same as the version of the `.csproj`, this would error out with a non-zero exit code. The issue occurs because AutoVer attempts to commit changes when no changes have been staged. This PR fixes that behavior to only attempt to commit changes when there are staged changes.